### PR TITLE
Scrub params

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ If you're using a nested set of attributes like this you'll need to let
       ]
 ```
 
+## Params scrubbing
+
+By default Überauth Identity will be changing empty values from the returned
+params to nil.
+If you want to disable that behaviour set the following option in your config:
+
+```elixir
+    config :ueberauth, Ueberauth,
+      providers: [
+        identity: {Ueberauth.Strategy.Identity, [scrub_params: false]}
+      ]
+```
+
 ## Calling
 
 Depending on the configured url you can initial the request through:

--- a/test/ueberauth/strategy/identity_test.exs
+++ b/test/ueberauth/strategy/identity_test.exs
@@ -97,4 +97,31 @@ defmodule Ueberauth.Strategy.IdentityTest do
     assert info.location == Map.get(opts, "user[location]")
     assert info.description == Map.get(opts, "user[description]")
   end
+
+  test "scrub params" do
+    opts = %{
+      email: "foo@example.com",
+      name: "",
+    }
+
+    query = URI.encode_query(opts)
+
+    conn = conn(:get, "/auth/identity/callback?#{query}") |> SpecRouter.call(@router)
+
+    assert conn.resp_body == "identity callback"
+
+    auth = conn.assigns.ueberauth_auth
+
+    assert auth.provider == :identity
+    assert auth.strategy == Ueberauth.Strategy.Identity
+    assert auth.uid == opts.email
+
+    info = auth.info
+    assert info.email == opts.email
+    assert info.name == nil
+
+    extra = auth.extra
+    assert extra.raw_info["email"] == opts.email
+    assert extra.raw_info["name"] == opts.name
+  end
 end

--- a/test/ueberauth/strategy/identity_test.exs
+++ b/test/ueberauth/strategy/identity_test.exs
@@ -62,7 +62,7 @@ defmodule Ueberauth.Strategy.IdentityTest do
     assert extra.raw_info["description"] == opts.description
   end
 
-  test "overwridden callback phase" do
+  test "overridden callback phase" do
     opts = %{
       "user[email]" => "foo@example.com",
       "user[name]" => "Fred Flintstone",


### PR DESCRIPTION
This replicates part of the behaviour of the `scrub_params` plug found
in Phoenix (in fact the code is ported from https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/controller.ex#L695-L701).

In my opinion this should be the default as in its current version it
doesn't play nicely with Ecto.

Fixes #7 
