### PR TITLE
Document config necessary to get assigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@
     ```elixir
     config :ueberauth, Ueberauth,
       providers: [
-        identity: {Ueberauth.Strategy.Identity, []}
+        identity: {Ueberauth.Strategy.Identity, [
+          callback_methods: ["POST"]
+        ]}
       ]
     ```
 


### PR DESCRIPTION
Without this, the documented `identity_callback` function will have an empty `assigns` key. This documentation change was taken from the `ueberauth_example` app
