### PR TITLE
Allow poison ~> 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,6 @@ defmodule UeberauthIdentity.Mixfile do
     [
       {:ueberauth, "~> 0.2"},
       {:plug, "~> 1.0"},
-      {:poison, "~> 1.5"},
 
       # docs dependencies
       {:earmark, "~> 0.1", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,4 @@
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
   "plug": {:hex, :plug, "1.0.3"},
-  "poison": {:hex, :poison, "1.5.0"},
   "ueberauth": {:hex, :ueberauth, "0.2.0"}}


### PR DESCRIPTION
Otherwise it breaks if any of your dependencies is using poison 2.0 or 2.1
