### PR TITLE
Fix warnings for Elixir 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ elixir: 1.4.0
 otp_release: 19.2
 matrix:
   include:
-    - elixir: 1.1.0
-      otp_release: 17.4
+    - elixir: 1.2.0
+      otp_release: 18.1
 env: MIX_ENV=test
 sudo: false # faster builds
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
-elixir:
-  - 1.1.0
-  - 1.2.0
-otp_release:
-  - 17.4
-  - 18.1
+elixir: 1.4.0
+otp_release: 19.2
+matrix:
+  include:
+    - elixir: 1.1.0
+      otp_release: 17.4
 env: MIX_ENV=test
 sudo: false # faster builds
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Überauth Identity
 [![Build Status][travis-img]][travis] [![Hex Version][hex-img]][hex] [![License][license-img]][license]
 
-[travis-img]: https://travis-ci.org/ueberauth/ueberauth_identity.png?branch=master
+[travis-img]: https://travis-ci.org/ueberauth/ueberauth_identity.svg?branch=master
 [travis]: https://travis-ci.org/ueberauth/ueberauth_identity
 [hex-img]: https://img.shields.io/hexpm/v/ueberauth_identity.svg
 [hex]: https://hex.pm/packages/ueberauth_identity

--- a/lib/ueberauth/strategy/identity.ex
+++ b/lib/ueberauth/strategy/identity.ex
@@ -54,7 +54,7 @@ defmodule Ueberauth.Strategy.Identity do
   end
 
   defp option(conn, name) do
-    Dict.get(options(conn), name, Dict.get(default_options, name))
+    Dict.get(options(conn), name, Dict.get(default_options(), name))
   end
 
   defp param_for(conn, name) do

--- a/lib/ueberauth/strategy/identity.ex
+++ b/lib/ueberauth/strategy/identity.ex
@@ -54,7 +54,7 @@ defmodule Ueberauth.Strategy.Identity do
   end
 
   defp option(conn, name) do
-    Dict.get(options(conn), name, Dict.get(default_options(), name))
+    Keyword.get(options(conn), name, Keyword.get(default_options(), name))
   end
 
   defp param_for(conn, name) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,15 +8,15 @@ defmodule UeberauthIdentity.Mixfile do
     [app: :ueberauth_identity,
      version: @version,
      name: "Ueberauth Identity",
-     package: package,
+     package: package(),
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: @url,
      homepage_url: @url,
-     description: description,
-     deps: deps,
-     docs: docs]
+     description: description(),
+     deps: deps(),
+     docs: docs()]
   end
 
   def application do
@@ -37,7 +37,7 @@ defmodule UeberauthIdentity.Mixfile do
   end
 
   defp docs do
-    [extras: docs_extras, main: "extra-readme"]
+    [extras: docs_extras(), main: "extra-readme"]
   end
 
   defp docs_extras do

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule UeberauthIdentity.Mixfile do
      version: @version,
      name: "Ueberauth Identity",
      package: package(),
-     elixir: "~> 1.1",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: @url,


### PR DESCRIPTION
I fixed a few warnings that were being output for function/variable ambiguity and the `Dict` module.