### PR TITLE
add ability to pass a list in param_nesting

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -10,5 +10,11 @@ config :ueberauth, Ueberauth,
         nickname_field: :username,
         param_nesting: "user"
       ]
+    },
+    identity_with_nested_options: {
+      Ueberauth.Strategy.Identity,
+      [
+        param_nesting: ["data", "attributes"]
+      ]
     }
   ]

--- a/lib/ueberauth/strategy/identity.ex
+++ b/lib/ueberauth/strategy/identity.ex
@@ -67,6 +67,16 @@ defmodule Ueberauth.Strategy.Identity do
     |> scrub_param(option(conn, :scrub_params))
   end
 
+  defp param_for(conn, name, nesting) when is_list(nesting) do
+    case Kernel.get_in(conn.params, Enum.map(nesting, fn(x) -> to_string(x) end)) do
+      nil -> nil
+      nested ->
+        nested
+        |> Map.get(to_string(option(conn, name)))
+        |> scrub_param(option(conn, :scrub_params))
+    end
+  end
+
   defp param_for(conn, name, nesting) do
     case Map.get(conn.params, to_string(nesting)) do
       nil -> nil

--- a/lib/ueberauth/strategy/identity.ex
+++ b/lib/ueberauth/strategy/identity.ex
@@ -68,7 +68,10 @@ defmodule Ueberauth.Strategy.Identity do
   end
 
   defp param_for(conn, name, nesting) when is_list(nesting) do
-    case Kernel.get_in(conn.params, Enum.map(nesting, fn(x) -> to_string(x) end)) do
+    case Kernel.get_in(
+      conn.params,
+      Enum.map(nesting, fn(x) -> to_string(x) end)
+    ) do
       nil -> nil
       nested ->
         nested

--- a/lib/ueberauth/strategy/identity.ex
+++ b/lib/ueberauth/strategy/identity.ex
@@ -67,21 +67,12 @@ defmodule Ueberauth.Strategy.Identity do
     |> scrub_param(option(conn, :scrub_params))
   end
 
-  defp param_for(conn, name, nesting) when is_list(nesting) do
-    case Kernel.get_in(
-      conn.params,
-      Enum.map(nesting, fn(x) -> to_string(x) end)
-    ) do
-      nil -> nil
-      nested ->
-        nested
-        |> Map.get(to_string(option(conn, name)))
-        |> scrub_param(option(conn, :scrub_params))
-    end
-  end
-
   defp param_for(conn, name, nesting) do
-    case Map.get(conn.params, to_string(nesting)) do
+    attrs = nesting
+    |> List.wrap
+    |> Enum.map(fn(item) -> to_string(item) end)
+
+    case Kernel.get_in(conn.params, attrs) do
       nil -> nil
       nested ->
         nested

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,6 +18,9 @@ defmodule SpecRouter do
   get "/auth/identity_with_options/callback" do
     send_resp(conn, 200, "identity with options callback")
   end
+  get "/auth/identity_with_nested_options/callback" do
+    send_resp(conn, 200, "identity with nested options callback")
+  end
 end
 
 ExUnit.start()

--- a/test/ueberauth/strategy/identity_test.exs
+++ b/test/ueberauth/strategy/identity_test.exs
@@ -105,6 +105,44 @@ defmodule Ueberauth.Strategy.IdentityTest do
     assert info.description == Map.get(opts, "user[description]")
   end
 
+  test "callback phase with nested params" do
+    opts = %{
+      "data[attributes][email]" => "foo@example.com",
+      "data[attributes][name]" => "Fred Flintstone",
+      "data[attributes][first_name]" => "Fred",
+      "data[attributes][last_name]" => "Flintstone",
+      "data[attributes][username]" => "freddy",
+      "data[attributes][phone]" =>  "555-555-5555",
+      "data[attributes][description]" => "Cave man",
+      "data[attributes][location]" => "Bedrock",
+      "data[attributes][password]" => "sekrit",
+      "data[attributes][password_confirmation]" => "sekrit"
+    }
+    query = URI.encode_query(opts)
+
+    conn = :get
+           |> conn("/auth/identity_with_nested_options/callback?#{query}")
+           |> SpecRouter.call(@router)
+
+    assert conn.resp_body == "identity with nested options callback"
+
+    auth = conn.assigns.ueberauth_auth
+
+    assert auth.provider == :identity_with_nested_options
+    assert auth.strategy == Ueberauth.Strategy.Identity
+    assert auth.uid == Map.get(opts, "data[attributes][email]")
+
+    info = auth.info
+    assert info.email == Map.get(opts, "data[attributes][email]")
+    assert info.name == Map.get(opts, "data[attributes][name]")
+    assert info.first_name == Map.get(opts, "data[attributes][first_name]")
+    assert info.last_name == Map.get(opts, "data[attributes][last_name]")
+    assert info.nickname == Map.get(opts, "data[attributes][nickname]")
+    assert info.phone == Map.get(opts, "data[attributes][phone]")
+    assert info.location == Map.get(opts, "data[attributes][location]")
+    assert info.description == Map.get(opts, "data[attributes][description]")
+  end
+
   test "scrub params" do
     opts = %{
       email: "foo@example.com",


### PR DESCRIPTION
This allows a list to be passed instead of just a string for a nested data structure.  One example for needing this is to comply with the jsonapi specs.  See #17 

Any feedback would be appreciated, I'm sure there are some ways this could be cleaned up a bit.
Thanks!