### PR TITLE
Fix docs section of mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule UeberauthIdentity.Mixfile do
   end
 
   defp docs do
-    [extras: docs_extras(), main: "extra-readme"]
+    [extras: docs_extras(), main: "readme"]
   end
 
   defp docs_extras do


### PR DESCRIPTION
Fixes #26 

`extra-readme` doc page doesn't exist. Switched to `readme` to fix.